### PR TITLE
Adding resolving logic to abstract types

### DIFF
--- a/src/Type/AbstractTypeInterface.php
+++ b/src/Type/AbstractTypeInterface.php
@@ -24,12 +24,12 @@ namespace GraphQL\Contracts\TypeSystem\Type;
 interface AbstractTypeInterface extends NamedTypeInterface
 {
     /**
-     * Resolves concrete ObjectTypeInterface for given object value
+     * Resolves concrete NamedTypeInterface for given object value
      *
      * @param object $objectValue
      * @param mixed $context
      * @param mixed ...$args
-     * @return ObjectTypeInterface|null
+     * @return NamedTypeInterface|null
      */
-    public function resolveType($objectValue, $context, ...$args): ?ObjectTypeInterface;
+    public function resolveType($objectValue, $context, ...$args): ?NamedTypeInterface;
 }

--- a/src/Type/AbstractTypeInterface.php
+++ b/src/Type/AbstractTypeInterface.php
@@ -23,5 +23,13 @@ namespace GraphQL\Contracts\TypeSystem\Type;
  */
 interface AbstractTypeInterface extends NamedTypeInterface
 {
-
+    /**
+     * Resolves concrete ObjectTypeInterface for given object value
+     *
+     * @param object $objectValue
+     * @param mixed $context
+     * @param mixed ...$args
+     * @return ObjectTypeInterface|null
+     */
+    public function resolveType($objectValue, $context, ...$args): ?ObjectTypeInterface;
 }


### PR DESCRIPTION
There are abstract types in GraphQL:
- `GraphQLInterfaceType`
- `GraphQLUnionType`

I suggest discussing which option (there are two options for implementation) is preferable and whether I took everything into account when adding this method.

## Existing solutions

### Webonyx

```php
namespace GraphQL\Type\Definition;

interface AbstractType
{
    public function resolveType($objectValue, $context, ResolveInfo $info);
}
```

### Digiaonline

```php
namespace Digia\GraphQL\Type\Definition;

interface AbstractTypeInterface 
/// ...some other methods
    public function resolveType(...$args);
    public function hasResolveTypeCallback(): bool;
}
```

### Youshido

```php
namespace Youshido\GraphQL\Type;

interface AbstractInterfaceTypeInterface
{
    public function resolveType($object);
}
```

## Result

```php
namespace GraphQL\Contracts\TypeSystem\Type;

interface AbstractTypeInterface extends NamedTypeInterface
{
    public function resolveType($objectValue, $context, ...$args): ?NamedTypeInterface;
}
```

1) Youshido will need to add `$context`, otherwise the interface is fully compatible.
2) Digiaonline will require combining the two methods into one, where `null` will mean the absence of a resolver method.

## Some notes

1) Because the implementation of `ResolveInfo` class is different for everyone, it was decided to make the third argument arbitrary. It will suit every decision.
2) The method should return an object or interface type (https://github.com/graphql/graphql-js/pull/2084) therefore, it was decided to specify the `NamedTypeInterface` common interface as a return typehint.

## Alternative solution

```php
namespace GraphQL\Contracts\TypeSystem\Type;

interface AbstractTypeInterface extends NamedTypeInterface
{
    public function resolveType($objectValue, ...$args): ?NamedTypeInterface;
}
```

Removing the second argument will simplify integration into Youshido.